### PR TITLE
Add impl for build provider build mailbox and build validator announce

### DIFF
--- a/rust/main/chains/hyperlane-sovereign/Cargo.toml
+++ b/rust/main/chains/hyperlane-sovereign/Cargo.toml
@@ -7,6 +7,3 @@ edition.workspace = true
 async-trait.workspace = true
 
 hyperlane-core = { path = "../../hyperlane-core", features = ["async"] }
-
-# [build-dependencies]
-# abigen = { path = "../../utils/abigen", features = ["fuels"] }

--- a/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
@@ -1,31 +1,30 @@
-use crate::{
-    /*contracts::mailbox::Mailbox as FuelMailboxInner, */ ConnectionConf, SovereignProvider,
-};
+use crate::{ConnectionConf, SovereignProvider};
 use async_trait::async_trait;
 use hyperlane_core::{
     ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain,
     HyperlaneMessage, HyperlaneProvider, Mailbox, TxCostEstimate, TxOutcome, H256, U256,
 };
-use std::{
-    fmt::{Debug, Formatter},
-    num::NonZeroU64,
-};
+use std::{fmt::Debug, num::NonZeroU64};
 
 /// A reference to a Mailbox contract on some Sovereign chain.
+#[derive(Clone, Debug)]
 pub struct SovereignMailbox {
-    // contract: FuelMailboxInner<WalletUnlocked>,
     provider: SovereignProvider,
     domain: HyperlaneDomain,
+    #[allow(dead_code)]
+    config: ConnectionConf,
 }
 
 impl SovereignMailbox {
     /// Create a new sovereign mailbox
     pub async fn new(conf: &ConnectionConf, locator: ContractLocator<'_>) -> ChainResult<Self> {
-        let sovereign_provider = SovereignProvider::new(locator.domain.clone(), conf).await;
+        let sovereign_provider =
+            SovereignProvider::new(locator.domain.clone(), &conf.clone()).await;
 
         Ok(SovereignMailbox {
             provider: sovereign_provider,
             domain: locator.domain.clone(),
+            config: conf.clone(),
         })
     }
 }
@@ -33,7 +32,6 @@ impl SovereignMailbox {
 impl HyperlaneContract for SovereignMailbox {
     fn address(&self) -> hyperlane_core::H256 {
         todo!("fn address(&self) -> hyperlane_core::H256")
-        // self.contract.contract_id().into_h256()
     }
 }
 
@@ -47,20 +45,23 @@ impl HyperlaneChain for SovereignMailbox {
     }
 }
 
-impl Debug for SovereignMailbox {
-    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
-        write!(f, "{:?}", self as &dyn HyperlaneContract)
-    }
-}
-
 #[async_trait]
 impl Mailbox for SovereignMailbox {
     async fn count(&self, _lag: Option<NonZeroU64>) -> ChainResult<u32> {
-        todo!("async fn count(&self, lag: Option<NonZeroU64>) -> ChainResult<u32>")
+        let count = self.provider.grpc().get_count().await?;
+
+        Ok(count)
     }
 
-    async fn delivered(&self, _id: H256) -> ChainResult<bool> {
-        todo!("async fn delivered(&self, id: H256) -> ChainResult<bool>")
+    async fn delivered(&self, id: H256) -> ChainResult<bool> {
+        let message_id = do_something_with_id(id);
+        let delivered = self
+            .provider
+            .grpc()
+            .get_delivered_status(message_id)
+            .await?;
+
+        Ok(delivered)
     }
 
     async fn default_ism(&self) -> ChainResult<H256> {
@@ -77,7 +78,9 @@ impl Mailbox for SovereignMailbox {
         _metadata: &[u8],
         _tx_gas_limit: Option<U256>,
     ) -> ChainResult<TxOutcome> {
-        todo!("async fn process(&self, message: &HyperlaneMessage, metadata: &[u8], tx_gas_limit: Option<U256>) -> ChainResult<TxOutcome>")
+        let _delivered = self.provider.grpc().process_message().await?;
+
+        todo!()
     }
 
     async fn process_estimate_costs(
@@ -91,4 +94,8 @@ impl Mailbox for SovereignMailbox {
     fn process_calldata(&self, _message: &HyperlaneMessage, _metadata: &[u8]) -> Vec<u8> {
         todo!("async fn process_calldata(&self, message: &HyperlaneMessage, metadata: &[u8]) -> Vec<u8>")
     }
+}
+
+fn do_something_with_id(_id: H256) -> u32 {
+    todo!()
 }

--- a/rust/main/chains/hyperlane-sovereign/src/provider.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider.rs
@@ -7,17 +7,29 @@ use hyperlane_core::{
 
 use crate::ConnectionConf;
 
-/// A wrapper around a fuel provider to get generic blockchain information.
+/// A wrapper around a Sovereign provider to get generic blockchain information.
 #[derive(Debug, Clone)]
 pub struct SovereignProvider {
     domain: HyperlaneDomain,
-    // provider: Provider,
-    // client: FuelClient,
+    client: SovClient,
+    provider: SovProvider,
 }
 
 impl SovereignProvider {
-    pub async fn new(domain: HyperlaneDomain, _conf: &ConnectionConf) -> Self {
-        Self { domain }
+    pub async fn new(domain: HyperlaneDomain, conf: &ConnectionConf) -> Self {
+        let provider = SovProvider::new(conf);
+        let client = SovClient::new(conf);
+
+        Self {
+            domain,
+            client,
+            provider,
+        }
+    }
+
+    /// Get a grpc client.
+    pub fn grpc(&self) -> &SovProvider {
+        &self.provider
     }
 }
 
@@ -34,22 +46,77 @@ impl HyperlaneChain for SovereignProvider {
 #[async_trait]
 impl HyperlaneProvider for SovereignProvider {
     async fn get_block_by_hash(&self, _hash: &H256) -> ChainResult<BlockInfo> {
-        todo!()
+        let block = self.client.get_block_by_hash().await?;
+        Ok(block)
     }
 
     async fn get_txn_by_hash(&self, _hash: &H256) -> ChainResult<TxnInfo> {
-        todo!()
+        let txn = self.client.get_txn_by_hash().await?;
+        Ok(txn)
     }
 
     async fn is_contract(&self, _address: &H256) -> ChainResult<bool> {
-        todo!()
+        let block = self.client.is_contract().await?;
+        Ok(block)
     }
 
     async fn get_balance(&self, _address: String) -> ChainResult<U256> {
+        let balance = self.client.get_balance().await?;
+        Ok(balance)
+    }
+
+    async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
+        let metrics = self.client.get_chain_metrics().await?;
+        Ok(metrics)
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SovClient {}
+
+impl SovClient {
+    fn new(_conf: &ConnectionConf) -> Self {
+        SovClient {}
+    }
+
+    async fn get_block_by_hash(&self) -> ChainResult<BlockInfo> {
+        todo!()
+    }
+
+    async fn get_txn_by_hash(&self) -> ChainResult<TxnInfo> {
+        todo!()
+    }
+
+    async fn is_contract(&self) -> ChainResult<bool> {
+        todo!()
+    }
+
+    async fn get_balance(&self) -> ChainResult<U256> {
         todo!()
     }
 
     async fn get_chain_metrics(&self) -> ChainResult<Option<ChainInfo>> {
-        Ok(None)
+        todo!()
+    }
+}
+
+#[derive(Clone, Debug)]
+pub struct SovProvider {}
+
+impl SovProvider {
+    fn new(_conf: &ConnectionConf) -> Self {
+        todo!()
+    }
+
+    pub async fn get_count(&self) -> ChainResult<u32> {
+        todo!()
+    }
+
+    pub async fn get_delivered_status(&self, _message_id: u32) -> ChainResult<bool> {
+        todo!()
+    }
+
+    pub async fn process_message(&self) -> ChainResult<bool> {
+        todo!()
     }
 }

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -136,6 +136,7 @@ impl ChainConnectionConf {
             Self::Ethereum(conf) => Some(&conf.operation_batch),
             Self::Cosmos(conf) => Some(&conf.operation_batch),
             Self::Sealevel(conf) => Some(&conf.operation_batch),
+            Self::Sovereign(conf) => Some(&conf.operation_batch),
             _ => None,
         }
     }
@@ -197,7 +198,11 @@ impl ChainConf {
                 )?;
                 Ok(Box::new(provider) as Box<dyn HyperlaneProvider>)
             }
-            ChainConnectionConf::Sovereign(_conf) => todo!(),
+            ChainConnectionConf::Sovereign(conf) => {
+                let provider =
+                    h_sovereign::SovereignProvider::new(locator.domain.clone(), conf).await;
+                Ok(Box::new(provider) as Box<dyn HyperlaneProvider>)
+            }
         }
         .context(ctx)
     }
@@ -231,7 +236,12 @@ impl ChainConf {
                     .map(|m| Box::new(m) as Box<dyn Mailbox>)
                     .map_err(Into::into)
             }
-            ChainConnectionConf::Sovereign(_conf) => todo!(),
+            ChainConnectionConf::Sovereign(conf) => {
+                h_sovereign::SovereignMailbox::new(conf, locator)
+                    .await
+                    .map(|m| Box::new(m) as Box<dyn Mailbox>)
+                    .map_err(Into::into)
+            }
         }
         .context(ctx)
     }


### PR DESCRIPTION
### Description

Move `todo!()`s into dedicated interface layer.

Note: This is only a 'foundational' commit. preparing for Sov interface readiness.

### Drive-by changes

No

### Related issues

NA

### Backward compatibility

Yes

### Testing

NA
