### PR TITLE
different sequencing for merkletree/dispatch/igp

### DIFF
--- a/rust/main/chains/hyperlane-sovereign/src/indexer.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/indexer.rs
@@ -1,4 +1,5 @@
 use crate::rest_client::{self, Tx, TxEvent};
+use async_trait::async_trait;
 use core::ops::RangeInclusive;
 use hex;
 use hyperlane_core::{
@@ -11,13 +12,15 @@ use tracing::info;
 // SovIndexer is a trait that contains default implementations for indexing
 // various different event types on the Sovereign chain to reduce code duplication in
 // e.g. SovereignMailboxIndexer, SovereignInterchainGasPaymasterIndexer, etc.
+#[async_trait]
 pub trait SovIndexer<T>: Indexer<T> + SequenceAwareIndexer<T>
 where
-    T: Into<Indexed<T>> + Debug + Clone,
+    T: Into<Indexed<T>> + Debug + Clone + Send,
 {
     // These are the guys that need to be implemented by the concrete indexer
     fn client(&self) -> &rest_client::SovereignRestClient;
     fn decode_event(&self, event: &TxEvent) -> ChainResult<T>;
+    async fn sequence_at_slot(&self, slot: u32) -> ChainResult<Option<u32>>;
     const EVENT_KEY: &'static str;
 
     // Default implementation of Indexer<T>
@@ -64,12 +67,9 @@ where
     // Default implementation of SequenceAwareIndexer<T>
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
         let (latest_slot, latest_batch) = self.client().get_latest_slot().await?;
-        let sequence = self
-            .client()
-            .get_count(NonZeroU64::new(latest_slot as u64))
-            .await?;
+        let sequence = self.sequence_at_slot(latest_slot).await?;
 
-        Ok((Some(sequence), latest_batch.unwrap_or_default()))
+        Ok((sequence, latest_batch.unwrap_or_default()))
     }
 
     // Helper function to process a single transaction

--- a/rust/main/chains/hyperlane-sovereign/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/interchain_gas.rs
@@ -34,6 +34,9 @@ impl crate::indexer::SovIndexer<InterchainGasPayment> for SovereignInterchainGas
     fn client(&self) -> &SovereignRestClient {
         &self.provider.client()
     }
+    async fn sequence_at_slot(&self, slot: u32) -> ChainResult<Option<u32>> {
+        Ok(None)
+    }
     fn decode_event(&self, _event: &TxEvent) -> ChainResult<InterchainGasPayment> {
         todo!()
     }

--- a/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
@@ -50,9 +50,19 @@ pub struct DispatchEventInner {
 #[async_trait]
 impl crate::indexer::SovIndexer<HyperlaneMessage> for SovereignMailboxIndexer {
     const EVENT_KEY: &'static str = "Mailbox/Dispatch";
+
     fn client(&self) -> &rest_client::SovereignRestClient {
         &self.provider.client()
     }
+
+    async fn sequence_at_slot(&self, slot: u32) -> ChainResult<Option<u32>> {
+        let sequence = self
+            .client()
+            .get_count(NonZeroU64::new(slot as u64))
+            .await?;
+        Ok(Some(sequence))
+    }
+
     fn decode_event(&self, event: &TxEvent) -> ChainResult<HyperlaneMessage> {
         let inner_event: DispatchEvent = serde_json::from_value(event.value.clone())?;
         let hex_msg = inner_event

--- a/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
@@ -4,6 +4,7 @@ use crate::{
     ConnectionConf, Signer, SovereignProvider,
 };
 use async_trait::async_trait;
+use bech32::{self, Bech32m, Hrp};
 use core::ops::RangeInclusive;
 use hyperlane_core::{
     accumulator::incremental::IncrementalMerkle, ChainResult, Checkpoint, ContractLocator,
@@ -16,6 +17,7 @@ use std::num::NonZeroU64;
 #[derive(Debug, Clone)]
 pub struct SovereignMerkleTreeHookIndexer {
     provider: Box<SovereignProvider>,
+    bech32_address: String,
 }
 
 impl SovereignMerkleTreeHookIndexer {
@@ -26,8 +28,18 @@ impl SovereignMerkleTreeHookIndexer {
     ) -> ChainResult<Self> {
         let provider = SovereignProvider::new(locator.domain.clone(), &conf, None).await;
 
+        let hrp = Hrp::parse("sov").expect("valid hrp"); // todo: put in config?
+        let mut bech32_address = String::new();
+        bech32::encode_to_fmt::<Bech32m, String>(
+            &mut bech32_address,
+            hrp,
+            locator.address.as_ref(),
+        )
+        .expect("failed to encode to buffer");
+
         Ok(SovereignMerkleTreeHookIndexer {
             provider: Box::new(provider),
+            bech32_address: bech32_address,
         })
     }
 }
@@ -35,8 +47,17 @@ impl SovereignMerkleTreeHookIndexer {
 #[async_trait]
 impl crate::indexer::SovIndexer<MerkleTreeInsertion> for SovereignMerkleTreeHookIndexer {
     const EVENT_KEY: &'static str = "Merkle/InsertedIntoTree";
+
     fn client(&self) -> &SovereignRestClient {
         &self.provider.client()
+    }
+
+    async fn sequence_at_slot(&self, slot: u32) -> ChainResult<Option<u32>> {
+        let sequence = self
+            .client()
+            .tree(&self.bech32_address, NonZeroU64::new(slot as u64))
+            .await?;
+        Ok(Some(sequence.count as u32))
     }
     fn decode_event(&self, _event: &TxEvent) -> ChainResult<MerkleTreeInsertion> {
         todo!()

--- a/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
@@ -757,11 +757,11 @@ impl SovereignRestClient {
     pub async fn tree(
         &self,
         hook_id: &str,
-        lag: Option<NonZeroU64>,
+        slot: Option<NonZeroU64>,
     ) -> ChainResult<IncrementalMerkle> {
         info!(
             "tree(&self, hook_id: &str, lag: Option<NonZeroU64>, hook_id:{:?} lag:{:?}",
-            hook_id, lag
+            hook_id, slot
         );
         #[derive(Clone, Debug, Deserialize)]
         struct Data {
@@ -770,7 +770,7 @@ impl SovereignRestClient {
         }
 
         // /mailbox-hook-merkle-tree/{hook_id}/tree
-        let query = match lag {
+        let query = match slot {
             Some(lag) => {
                 format!(
                     "modules/mailbox-hook-merkle-tree/{}/tree?rollup_height={}",

--- a/rust/main/hyperlane-base/src/contract_sync/cursors/mod.rs
+++ b/rust/main/hyperlane-base/src/contract_sync/cursors/mod.rs
@@ -57,8 +57,8 @@ impl Indexable for InterchainGasPayment {
             HyperlaneDomainProtocol::Cosmos => CursorType::RateLimited,
             HyperlaneDomainProtocol::Sovereign => {
                 info!("indexing_cursor(InterchainGasPayment domain: HyperlaneDomainProtocol)");
-                CursorType::SequenceAware
-            },
+                CursorType::RateLimited
+            }
         }
     }
 }
@@ -73,7 +73,7 @@ impl Indexable for MerkleTreeInsertion {
             HyperlaneDomainProtocol::Sovereign => {
                 info!("indexing_cursor(MerkleTreeInsertion domain: HyperlaneDomainProtocol)");
                 CursorType::SequenceAware
-            },
+            }
         }
     }
 }
@@ -88,7 +88,7 @@ impl Indexable for Delivery {
             HyperlaneDomainProtocol::Sovereign => {
                 info!("indexing_cursor(Delivery domain: HyperlaneDomainProtocol)");
                 todo!()
-            },
+            }
         }
     }
 }


### PR DESCRIPTION
Also now correctly bech32m encodes addresses (which have to be hex encoded in agent-config.json)