### PR TITLE
Use addresses from config file

### DIFF
--- a/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
@@ -1,6 +1,6 @@
 use crate::{
     indexer::SovIndexer,
-    rest_client::{SovereignRestClient, TxEvent},
+    rest_client::{to_bech32, SovereignRestClient, TxEvent},
     ConnectionConf, Signer, SovereignProvider,
 };
 use async_trait::async_trait;
@@ -131,25 +131,25 @@ impl HyperlaneContract for SovereignMerkleTreeHook {
 #[async_trait]
 impl MerkleTreeHook for SovereignMerkleTreeHook {
     async fn tree(&self, lag: Option<NonZeroU64>) -> ChainResult<IncrementalMerkle> {
-        let hook_id = "sov1pgd8mjuxe73m7jrvavjws3c6384gr34sket9mhkhyrtd5acwamn";
-        let tree = self.provider.client().tree(hook_id, lag).await?;
+        let hook_id = to_bech32(self.address);
+        let tree = self.provider.client().tree(&hook_id, lag).await?;
 
         Ok(tree)
     }
 
     async fn count(&self, lag: Option<NonZeroU64>) -> ChainResult<u32> {
-        let hook_id = "sov1pgd8mjuxe73m7jrvavjws3c6384gr34sket9mhkhyrtd5acwamn";
-        let tree = self.provider.client().tree(hook_id, lag).await?;
+        let hook_id = to_bech32(self.address);
+        let tree = self.provider.client().tree(&hook_id, lag).await?;
 
         Ok(tree.count as u32)
     }
 
     async fn latest_checkpoint(&self, lag: Option<NonZeroU64>) -> ChainResult<Checkpoint> {
-        let hook_id = "sov1pgd8mjuxe73m7jrvavjws3c6384gr34sket9mhkhyrtd5acwamn";
+        let hook_id = to_bech32(self.address);
         let checkpoint = self
             .provider
             .client()
-            .latest_checkpoint(hook_id, lag)
+            .latest_checkpoint(&hook_id, lag)
             .await?;
 
         Ok(checkpoint)

--- a/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
@@ -53,7 +53,7 @@ struct Errors {
     _title: Option<String>,
 }
 
-fn to_bech32(input: H256) -> String {
+pub fn to_bech32(input: H256) -> String {
     let hrp = Hrp::parse("sov").expect("valid hrp"); // todo: put in config?
     let mut bech32_address = String::new();
     // TODO: Will address always be 28 bytes?
@@ -430,23 +430,22 @@ impl SovereignRestClient {
             "get_balance(&self, token_id: &str, address: &str) token_id:{:?} address:{:?}",
             token_id, address
         );
-        let address = "sov1dnhqk4mdsj2kwv4xymt8a624xuahfx8906j9usdkx7ensfghndkq8p33f7";
 
-        // /modules/bank/tokens/{token_id}/balances/{address}
-        let query = format!("/modules/bank/tokens/{}/balances/{}", token_id, address);
+        // // /modules/bank/tokens/{token_id}/balances/{address}
+        // let query = format!("/modules/bank/tokens/{}/balances/{}", token_id, address);
 
-        #[derive(Clone, Debug, Deserialize)]
-        struct Data {
-            _amount: Option<u128>,
-            _token_id: Option<String>,
-        }
+        // #[derive(Clone, Debug, Deserialize)]
+        // struct Data {
+        //     _amount: Option<u128>,
+        //     _token_id: Option<String>,
+        // }
 
-        let response = self
-            .http_get(&query)
-            .await
-            .map_err(|e| ChainCommunicationError::CustomError(format!("HTTP Get Error: {}", e)))?;
-        let response: Schema<Data> = serde_json::from_slice(&response)?;
-        println!("PARSED RESPONSE: {:?}\n", response);
+        // let response = self
+        //     .http_get(&query)
+        //     .await
+        //     .map_err(|e| ChainCommunicationError::CustomError(format!("HTTP Get Error: {}", e)))?;
+        // let response: Schema<Data> = serde_json::from_slice(&response)?;
+        // println!("PARSED RESPONSE: {:?}\n", response);
 
         // let response = U256::from(response);
         Ok(U256::default())


### PR DESCRIPTION
### Description

Remove hard-coded merkle tree addresses and parse from config file. Remove endpoint query causing innocuous 404.

### Drive-by changes

no

### Related issues

NA

### Backward compatibility

yes

### Testing

manual
