### PR TITLE
Left padded addresses

### DIFF
--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -3023,11 +3023,8 @@ dependencies = [
  "serde_json",
  "sha3 0.10.8",
  "sov-api-spec",
+ "sov-bank",
  "sov-cli",
- "sov-hl-hook",
- "sov-hl-ism-registry",
- "sov-hl-mailbox",
- "sov-hl-recipient",
  "sov-hyperlane",
  "sov-modules-api",
  "sov-rollup-interface",
@@ -3052,10 +3049,7 @@ dependencies = [
  "sov-chain-state",
  "sov-cli",
  "sov-evm",
- "sov-hl-hook",
- "sov-hl-ism-registry",
- "sov-hl-mailbox",
- "sov-hl-recipient",
+ "sov-hyperlane",
  "sov-kernels",
  "sov-mock-da",
  "sov-modules-api",
@@ -6116,7 +6110,6 @@ dependencies = [
  "serde",
  "serde_json",
  "sov-address",
- "sov-hl-mailbox",
  "sov-hyperlane",
  "sov-modules-api",
  "sov-rollup-interface",
@@ -12884,15 +12877,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "sov-hl-hook"
+name = "sov-hyperlane"
 version = "0.1.0"
 dependencies = [
  "anyhow",
  "bnum 0.12.1",
  "borsh 1.5.3",
- "clap 4.5.26",
- "cosmwasm-std 1.5.7",
- "enum_dispatch",
  "ethereum-types 0.15.1",
  "hpl-interface",
  "jsonrpsee",
@@ -12902,102 +12892,11 @@ dependencies = [
  "serde_with",
  "sha3 0.10.8",
  "sov-bank",
- "sov-hyperlane",
  "sov-modules-api",
  "sov-modules-macros",
  "sov-rollup-interface",
  "sov-state",
  "strum 0.26.3",
-]
-
-[[package]]
-name = "sov-hl-ism-registry"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "borsh 1.5.3",
- "clap 4.5.26",
- "cosmwasm-std 1.5.7",
- "hpl-interface",
- "jsonrpsee",
- "schemars",
- "serde",
- "serde_with",
- "sha3 0.10.8",
- "sov-modules-api",
- "sov-modules-macros",
- "sov-rollup-interface",
- "sov-state",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "sov-hl-mailbox"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "borsh 1.5.3",
- "clap 4.5.26",
- "cosmwasm-std 1.5.7",
- "hpl-interface",
- "jsonrpsee",
- "schemars",
- "serde",
- "serde_with",
- "sha3 0.10.8",
- "sov-hl-hook",
- "sov-hl-ism-registry",
- "sov-hl-recipient",
- "sov-hyperlane",
- "sov-modules-api",
- "sov-modules-macros",
- "sov-rollup-interface",
- "sov-state",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "sov-hl-recipient"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "borsh 1.5.3",
- "cosmwasm-std 1.5.7",
- "enum_dispatch",
- "ethereum-types 0.15.1",
- "hpl-interface",
- "jsonrpsee",
- "schemars",
- "serde",
- "serde_with",
- "sha3 0.10.8",
- "sov-bank",
- "sov-hyperlane",
- "sov-modules-api",
- "sov-modules-macros",
- "sov-rollup-interface",
- "sov-state",
- "strum 0.26.3",
-]
-
-[[package]]
-name = "sov-hyperlane"
-version = "0.1.0"
-dependencies = [
- "anyhow",
- "bnum 0.12.1",
- "borsh 1.5.3",
- "cosmwasm-std 1.5.7",
- "ethereum-types 0.15.1",
- "hpl-interface",
- "jsonrpsee",
- "serde",
- "serde_with",
- "sha3 0.10.8",
- "sov-modules-api",
- "sov-modules-macros",
- "sov-rollup-interface",
- "sov-state",
 ]
 
 [[package]]

--- a/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
@@ -7,7 +7,9 @@ use async_trait::async_trait;
 use core::ops::RangeInclusive;
 use hex;
 use hyperlane_core::{
-    ChainCommunicationError, ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract, HyperlaneDomain, HyperlaneMessage, HyperlaneProvider, Indexed, Indexer, LogMeta, Mailbox, RawHyperlaneMessage, SequenceAwareIndexer, TxCostEstimate, TxOutcome, H256, H512, U256
+    ChainCommunicationError, ChainResult, ContractLocator, HyperlaneChain, HyperlaneContract,
+    HyperlaneDomain, HyperlaneMessage, HyperlaneProvider, Indexed, Indexer, LogMeta, Mailbox,
+    RawHyperlaneMessage, SequenceAwareIndexer, TxCostEstimate, TxOutcome, H256, H512, U256,
 };
 use serde::Deserialize;
 use std::{fmt::Debug, num::NonZeroU64};
@@ -158,11 +160,7 @@ impl Mailbox for SovereignMailbox {
 
     async fn delivered(&self, id: H256) -> ChainResult<bool> {
         println!("id: {:?}", id);
-        let delivered = self
-            .provider
-            .client()
-            .get_delivered_status(id)
-            .await?;
+        let delivered = self.provider.client().get_delivered_status(id).await?;
 
         Ok(delivered)
     }
@@ -185,7 +183,11 @@ impl Mailbox for SovereignMailbox {
         metadata: &[u8],
         tx_gas_limit: Option<U256>,
     ) -> ChainResult<TxOutcome> {
-        let result = self.provider.client().process(message, metadata, tx_gas_limit).await?;
+        let result = self
+            .provider
+            .client()
+            .process(message, metadata, tx_gas_limit)
+            .await?;
 
         Ok(result)
     }
@@ -205,8 +207,9 @@ impl Mailbox for SovereignMailbox {
     }
 
     fn process_calldata(&self, _message: &HyperlaneMessage, _metadata: &[u8]) -> Vec<u8> {
-        let calldata = self.provider.client().process_calldata();
+        // let calldata = self.provider.client().process_calldata();
 
-        calldata
+        // calldata
+        todo!()
     }
 }

--- a/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
@@ -4,7 +4,6 @@ use crate::{
     ConnectionConf, Signer, SovereignProvider,
 };
 use async_trait::async_trait;
-use bech32::{self, Bech32m, Hrp};
 use core::ops::RangeInclusive;
 use hyperlane_core::{
     accumulator::incremental::IncrementalMerkle, ChainResult, Checkpoint, ContractLocator,
@@ -29,17 +28,9 @@ impl SovereignMerkleTreeHookIndexer {
         _signer: Option<Signer>,
     ) -> ChainResult<Self> {
         let provider = SovereignProvider::new(locator.domain.clone(), &conf, None).await;
-
-        let hrp = Hrp::parse("sov").expect("valid hrp"); // todo: put in config?
-        let mut bech32_address = String::new();
-        // TODO: How to check if address is actually 28 bytes
-        let addr_224 = &locator.address.as_ref()[..28];
-        bech32::encode_to_fmt::<Bech32m, String>(&mut bech32_address, hrp, addr_224)
-            .expect("failed to encode to buffer");
-
         Ok(SovereignMerkleTreeHookIndexer {
             provider: Box::new(provider),
-            bech32_address: bech32_address,
+            bech32_address: to_bech32(locator.address)?,
         })
     }
 }
@@ -156,21 +147,21 @@ impl HyperlaneContract for SovereignMerkleTreeHook {
 #[async_trait]
 impl MerkleTreeHook for SovereignMerkleTreeHook {
     async fn tree(&self, lag: Option<NonZeroU64>) -> ChainResult<IncrementalMerkle> {
-        let hook_id = to_bech32(self.address);
+        let hook_id = to_bech32(self.address)?;
         let tree = self.provider.client().tree(&hook_id, lag).await?;
 
         Ok(tree)
     }
 
     async fn count(&self, lag: Option<NonZeroU64>) -> ChainResult<u32> {
-        let hook_id = to_bech32(self.address);
+        let hook_id = to_bech32(self.address)?;
         let tree = self.provider.client().tree(&hook_id, lag).await?;
 
         Ok(tree.count as u32)
     }
 
     async fn latest_checkpoint(&self, lag: Option<NonZeroU64>) -> ChainResult<Checkpoint> {
-        let hook_id = to_bech32(self.address);
+        let hook_id = to_bech32(self.address)?;
         let checkpoint = self
             .provider
             .client()

--- a/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
@@ -53,23 +53,50 @@ struct Errors {
     _title: Option<String>,
 }
 
-pub fn to_bech32(input: H256) -> String {
+pub fn to_bech32(input: H256) -> ChainResult<String> {
     let hrp = Hrp::parse("sov").expect("valid hrp"); // todo: put in config?
     let mut bech32_address = String::new();
-    // TODO: Will address always be 28 bytes?
-    let addr_224 = &input.as_ref()[..28];
-    bech32::encode_to_fmt::<Bech32m, String>(&mut bech32_address, hrp, addr_224)
-        .expect("failed to encode to buffer");
-    bech32_address
+    let addr = input.as_ref();
+
+    match addr.len() {
+        28 => {
+            bech32::encode_to_fmt::<Bech32m, String>(&mut bech32_address, hrp, addr).map_err(
+                |e| ChainCommunicationError::CustomError(format!("bech32 encoding error: {:?}", e)),
+            )?;
+
+            Ok(bech32_address)
+        }
+        32 if addr[..4] == [0, 0, 0, 0] => {
+            bech32::encode_to_fmt::<Bech32m, String>(&mut bech32_address, hrp, &addr[4..])
+                .map_err(|e| {
+                    ChainCommunicationError::CustomError(format!("bech32 encoding error: {:?}", e))
+                })?;
+
+            Ok(bech32_address)
+        }
+        _ => Err(ChainCommunicationError::CustomError(format!(
+            "bech_32 encoding error: Address must be 28 bytes, received {:?}",
+            addr
+        ))),
+    }
 }
 
-fn from_bech32(input: String) -> H256 {
-    let (_, slice) = bech32::decode(&input).expect("failed to decode");
-    // TODO: Will address always be 28 bytes?
-    assert!(slice.len() == 28);
-    let mut array = [0u8; 32];
-    array[..28].copy_from_slice(slice.as_ref());
-    H256::from_slice(&array)
+fn from_bech32(input: String) -> ChainResult<H256> {
+    let (_, slice) = bech32::decode(&input).map_err(|e| {
+        ChainCommunicationError::CustomError(format!("bech32 decoding error: {:?}", e))
+    })?;
+
+    match slice.len() {
+        28 => {
+            let mut array = [0u8; 32];
+            array[4..].copy_from_slice(slice.as_ref());
+            Ok(H256::from_slice(&array))
+        }
+        _ => Err(ChainCommunicationError::CustomError(format!(
+            "bech_32 encoding error: Address must be 28 bytes, received {:?}",
+            slice
+        ))),
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -412,7 +439,7 @@ impl SovereignRestClient {
             let query = format!(
                 "/modules/{}/state/registry/items/{}",
                 module,
-                to_bech32(key)
+                to_bech32(key)?
             );
 
             let response = self.http_get(&query).await.map_err(|e| {
@@ -551,7 +578,7 @@ impl SovereignRestClient {
             .map_err(|e| ChainCommunicationError::CustomError(format!("HTTP Get Error: {}", e)))?;
         let response: Schema<Data> = serde_json::from_slice(&response)?;
         let addr_bech32 = response.data.unwrap().value.unwrap();
-        let addr_h256 = from_bech32(addr_bech32);
+        let addr_h256 = from_bech32(addr_bech32)?;
         Ok(addr_h256)
     }
 
@@ -563,7 +590,7 @@ impl SovereignRestClient {
             address: Option<String>,
         }
 
-        let recipient_bech32 = to_bech32(recipient_id);
+        let recipient_bech32 = to_bech32(recipient_id)?;
 
         let query = format!(
             "/modules/mailbox-recipient-registry/{}/ism",
@@ -577,7 +604,7 @@ impl SovereignRestClient {
         let response: Schema<Data> = serde_json::from_slice(&response)?;
 
         let addr_bech32 = response.data.unwrap().address.unwrap();
-        let addr_h256 = from_bech32(addr_bech32);
+        let addr_h256 = from_bech32(addr_bech32)?;
         Ok(addr_h256)
     }
 
@@ -804,7 +831,7 @@ impl SovereignRestClient {
 
         let query = format!(
             "/modules/mailbox-ism-registry/{}/module_type/",
-            to_bech32(ism_id)
+            to_bech32(ism_id)?
         );
 
         // #[derive(Debug, Deserialize, Clone)]
@@ -927,7 +954,7 @@ impl SovereignRestClient {
         println!("response: {:?}", response);
 
         let response = Checkpoint {
-            merkle_tree_hook_address: from_bech32(String::from(hook_id)),
+            merkle_tree_hook_address: from_bech32(String::from(hook_id))?,
             mailbox_domain: 4321, // todo...obviously
             root: H256::from_str(&response.data.clone().unwrap().root.unwrap())?,
             index: response.data.clone().unwrap().index.unwrap(),


### PR DESCRIPTION
### Description

Change `to_bech32` and `from_bech32` functions to left pad from right pad. Return `Result<T>`

### Drive-by changes

No

### Related issues

NA

### Backward compatibility

Yes

### Testing

Manual