### PR TITLE
Update indexer to use slot numbers, match upstream endpoints.

### DIFF
--- a/rust/main/chains/hyperlane-sovereign/src/indexer.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/indexer.rs
@@ -20,7 +20,7 @@ where
 {
     fn client(&self) -> &rest_client::SovereignRestClient;
     fn decode_event(&self, event: &TxEvent) -> ChainResult<T>;
-    async fn latest_sequence(&self, at_slot: u64) -> ChainResult<Option<u32>>;
+    async fn latest_sequence(&self, at_slot: Option<u64>) -> ChainResult<Option<u32>>;
     const EVENT_KEY: &'static str;
 
     // Default implementation of Indexer<T>
@@ -28,8 +28,6 @@ where
         &self,
         range: RangeInclusive<u32>,
     ) -> ChainResult<Vec<(Indexed<T>, LogMeta)>> {
-        // wait for new slot to appear at ledger...
-        tokio::time::sleep(std::time::Duration::from_millis(400)).await;
         let logs = range
             .map(|slot_num| async move {
                 let slot = self.client().get_slot(slot_num.into()).await?;
@@ -71,7 +69,7 @@ where
     // Default implementation of SequenceAwareIndexer<T>
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
         let finalized_slot = self.client().get_finalized_slot().await?;
-        let sequence = self.latest_sequence(finalized_slot).await?;
+        let sequence = self.latest_sequence(Some(finalized_slot)).await?;
         let latest_slot = self.client().get_latest_slot().await? + 1;
 
         Ok((

--- a/rust/main/chains/hyperlane-sovereign/src/indexer.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/indexer.rs
@@ -69,7 +69,7 @@ where
     // Default implementation of SequenceAwareIndexer<T>
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
         let finalized_slot = self.client().get_finalized_slot().await?;
-        let sequence = self.latest_sequence(Some(finalized_slot)).await?;
+        let sequence = self.latest_sequence(finalized_slot).await?;
         let latest_slot = self.client().get_latest_slot().await? + 1;
 
         Ok((

--- a/rust/main/chains/hyperlane-sovereign/src/indexer.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/indexer.rs
@@ -20,7 +20,7 @@ where
 {
     fn client(&self) -> &rest_client::SovereignRestClient;
     fn decode_event(&self, event: &TxEvent) -> ChainResult<T>;
-    async fn latest_sequence(&self) -> ChainResult<Option<u32>>;
+    async fn latest_sequence(&self, at_slot: u64) -> ChainResult<Option<u32>>;
     const EVENT_KEY: &'static str;
 
     // Default implementation of Indexer<T>
@@ -70,10 +70,8 @@ where
 
     // Default implementation of SequenceAwareIndexer<T>
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
-        // todo: workaround; it should be
-        // let finalized_slot = self.client().get_finalized_slot().await?;
-        // let sequence = self.latest_sequence(finalized_slot).await?;
-        let sequence = self.latest_sequence().await?;
+        let finalized_slot = self.client().get_finalized_slot().await?;
+        let sequence = self.latest_sequence(finalized_slot).await?;
         let latest_slot = self.client().get_latest_slot().await? + 1;
 
         Ok((

--- a/rust/main/chains/hyperlane-sovereign/src/indexer.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/indexer.rs
@@ -69,12 +69,13 @@ where
     // Default implementation of SequenceAwareIndexer<T>
     async fn latest_sequence_count_and_tip(&self) -> ChainResult<(Option<u32>, u32)> {
         let finalized_slot = self.client().get_finalized_slot().await?;
-        let sequence = self.latest_sequence(finalized_slot).await?;
-        let latest_slot = self.client().get_latest_slot().await? + 1;
+        let sequence = self.latest_sequence(Some(finalized_slot)).await?;
 
         Ok((
             sequence,
-            latest_slot.try_into().expect("Slot number overflowed u32"),
+            finalized_slot
+                .try_into()
+                .map_err(|e| ChainCommunicationError::CustomError(format!("{e:?}")))?,
         ))
     }
 

--- a/rust/main/chains/hyperlane-sovereign/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/interchain_gas.rs
@@ -34,7 +34,7 @@ impl crate::indexer::SovIndexer<InterchainGasPayment> for SovereignInterchainGas
     fn client(&self) -> &SovereignRestClient {
         self.provider.client()
     }
-    async fn latest_sequence(&self, _at_slot: u64) -> ChainResult<Option<u32>> {
+    async fn latest_sequence(&self, _at_slot: Option<u64>) -> ChainResult<Option<u32>> {
         Ok(None)
     }
     fn decode_event(&self, _event: &TxEvent) -> ChainResult<InterchainGasPayment> {

--- a/rust/main/chains/hyperlane-sovereign/src/interchain_gas.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/interchain_gas.rs
@@ -34,7 +34,7 @@ impl crate::indexer::SovIndexer<InterchainGasPayment> for SovereignInterchainGas
     fn client(&self) -> &SovereignRestClient {
         self.provider.client()
     }
-    async fn latest_sequence(&self) -> ChainResult<Option<u32>> {
+    async fn latest_sequence(&self, _at_slot: u64) -> ChainResult<Option<u32>> {
         Ok(None)
     }
     fn decode_event(&self, _event: &TxEvent) -> ChainResult<InterchainGasPayment> {

--- a/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
@@ -58,8 +58,8 @@ impl crate::indexer::SovIndexer<HyperlaneMessage> for SovereignMailboxIndexer {
         self.provider.client()
     }
 
-    async fn latest_sequence(&self) -> ChainResult<Option<u32>> {
-        let sequence = self.client().get_count(None).await?;
+    async fn latest_sequence(&self, at_slot: u64) -> ChainResult<Option<u32>> {
+        let sequence = self.client().get_count(Some(at_slot.try_into().unwrap())).await?;
         Ok(Some(sequence))
     }
 

--- a/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
@@ -152,9 +152,9 @@ impl HyperlaneChain for SovereignMailbox {
 
 #[async_trait]
 impl Mailbox for SovereignMailbox {
-    async fn count(&self, reorg_period: &ReorgPeriod) -> ChainResult<u32> {
-        let lag = Some(reorg_period.as_blocks()?.into());
-        let count = self.provider.client().get_count(lag).await?;
+    async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
+        let slot = self.provider.client().get_finalized_slot().await?;
+        let count = self.provider.client().get_count(slot).await?;
 
         Ok(count)
     }

--- a/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
@@ -154,7 +154,7 @@ impl HyperlaneChain for SovereignMailbox {
 impl Mailbox for SovereignMailbox {
     async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
         let slot = self.provider.client().get_finalized_slot().await?;
-        let count = self.provider.client().get_count(slot).await?;
+        let count = self.provider.client().get_count(Some(slot)).await?;
 
         Ok(count)
     }

--- a/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/mailbox.rs
@@ -58,8 +58,8 @@ impl crate::indexer::SovIndexer<HyperlaneMessage> for SovereignMailboxIndexer {
         self.provider.client()
     }
 
-    async fn latest_sequence(&self, at_slot: u64) -> ChainResult<Option<u32>> {
-        let sequence = self.client().get_count(Some(at_slot.try_into().unwrap())).await?;
+    async fn latest_sequence(&self, at_slot: Option<u64>) -> ChainResult<Option<u32>> {
+        let sequence = self.client().get_count(at_slot).await?;
         Ok(Some(sequence))
     }
 
@@ -153,7 +153,7 @@ impl HyperlaneChain for SovereignMailbox {
 #[async_trait]
 impl Mailbox for SovereignMailbox {
     async fn count(&self, reorg_period: &ReorgPeriod) -> ChainResult<u32> {
-        let lag = Some(reorg_period.as_blocks()?);
+        let lag = Some(reorg_period.as_blocks()?.into());
         let count = self.provider.client().get_count(lag).await?;
 
         Ok(count)

--- a/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
@@ -162,16 +162,16 @@ impl HyperlaneContract for SovereignMerkleTreeHook {
 
 #[async_trait]
 impl MerkleTreeHook for SovereignMerkleTreeHook {
-    async fn tree(&self, reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkle> {
-        let lag = Some(reorg_period.as_blocks()?.into());
-        let tree = self.provider.client().tree(lag).await?;
+    async fn tree(&self, _reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkle> {
+        let slot = self.provider.client().get_finalized_slot().await?;
+        let tree = self.provider.client().tree(slot).await?;
 
         Ok(tree)
     }
 
-    async fn count(&self, reorg_period: &ReorgPeriod) -> ChainResult<u32> {
-        let lag = Some(reorg_period.as_blocks()?.into());
-        let tree = self.provider.client().tree(lag).await?;
+    async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
+        let slot = self.provider.client().get_finalized_slot().await?;
+        let tree = self.provider.client().tree(slot).await?;
 
         match u32::try_from(tree.count) {
             Ok(x) => Ok(x),
@@ -181,13 +181,13 @@ impl MerkleTreeHook for SovereignMerkleTreeHook {
         }
     }
 
-    async fn latest_checkpoint(&self, reorg_period: &ReorgPeriod) -> ChainResult<Checkpoint> {
-        let lag = Some(reorg_period.as_blocks()?.into());
+    async fn latest_checkpoint(&self, _reorg_period: &ReorgPeriod) -> ChainResult<Checkpoint> {
+        let slot = self.provider.client().get_finalized_slot().await?;
         let hook_id = to_bech32(self.address)?;
         let checkpoint = self
             .provider
             .client()
-            .latest_checkpoint(&hook_id, lag, self.domain.id())
+            .latest_checkpoint(&hook_id, slot, self.domain.id())
             .await?;
 
         Ok(checkpoint)

--- a/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
@@ -41,8 +41,8 @@ impl crate::indexer::SovIndexer<MerkleTreeInsertion> for SovereignMerkleTreeHook
         self.provider.client()
     }
 
-    async fn latest_sequence(&self) -> ChainResult<Option<u32>> {
-        let sequence = self.client().tree(None).await?;
+    async fn latest_sequence(&self, at_slot: u64) -> ChainResult<Option<u32>> {
+        let sequence = self.client().tree(Some(at_slot.try_into().unwrap())).await?;
 
         match u32::try_from(sequence.count) {
             Ok(x) => Ok(Some(x)),

--- a/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
@@ -164,14 +164,14 @@ impl HyperlaneContract for SovereignMerkleTreeHook {
 impl MerkleTreeHook for SovereignMerkleTreeHook {
     async fn tree(&self, _reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkle> {
         let slot = self.provider.client().get_finalized_slot().await?;
-        let tree = self.provider.client().tree(slot).await?;
+        let tree = self.provider.client().tree(Some(slot)).await?;
 
         Ok(tree)
     }
 
     async fn count(&self, _reorg_period: &ReorgPeriod) -> ChainResult<u32> {
         let slot = self.provider.client().get_finalized_slot().await?;
-        let tree = self.provider.client().tree(slot).await?;
+        let tree = self.provider.client().tree(Some(slot)).await?;
 
         match u32::try_from(tree.count) {
             Ok(x) => Ok(x),
@@ -187,7 +187,7 @@ impl MerkleTreeHook for SovereignMerkleTreeHook {
         let checkpoint = self
             .provider
             .client()
-            .latest_checkpoint(&hook_id, slot, self.domain.id())
+            .latest_checkpoint(&hook_id, Some(slot), self.domain.id())
             .await?;
 
         Ok(checkpoint)

--- a/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
@@ -41,8 +41,8 @@ impl crate::indexer::SovIndexer<MerkleTreeInsertion> for SovereignMerkleTreeHook
         self.provider.client()
     }
 
-    async fn latest_sequence(&self, at_slot: u64) -> ChainResult<Option<u32>> {
-        let sequence = self.client().tree(Some(at_slot.try_into().unwrap())).await?;
+    async fn latest_sequence(&self, at_slot: Option<u64>) -> ChainResult<Option<u32>> {
+        let sequence = self.client().tree(at_slot).await?;
 
         match u32::try_from(sequence.count) {
             Ok(x) => Ok(Some(x)),
@@ -163,14 +163,14 @@ impl HyperlaneContract for SovereignMerkleTreeHook {
 #[async_trait]
 impl MerkleTreeHook for SovereignMerkleTreeHook {
     async fn tree(&self, reorg_period: &ReorgPeriod) -> ChainResult<IncrementalMerkle> {
-        let lag = Some(reorg_period.as_blocks()?);
+        let lag = Some(reorg_period.as_blocks()?.into());
         let tree = self.provider.client().tree(lag).await?;
 
         Ok(tree)
     }
 
     async fn count(&self, reorg_period: &ReorgPeriod) -> ChainResult<u32> {
-        let lag = Some(reorg_period.as_blocks()?);
+        let lag = Some(reorg_period.as_blocks()?.into());
         let tree = self.provider.client().tree(lag).await?;
 
         match u32::try_from(tree.count) {
@@ -182,7 +182,7 @@ impl MerkleTreeHook for SovereignMerkleTreeHook {
     }
 
     async fn latest_checkpoint(&self, reorg_period: &ReorgPeriod) -> ChainResult<Checkpoint> {
-        let lag = Some(reorg_period.as_blocks()?);
+        let lag = Some(reorg_period.as_blocks()?.into());
         let hook_id = to_bech32(self.address)?;
         let checkpoint = self
             .provider

--- a/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
@@ -458,13 +458,11 @@ impl SovereignRestClient {
     }
 
     // @Mailbox
-    pub async fn get_count(&self, at_height: Option<u32>) -> ChainResult<u32> {
+    pub async fn get_count(&self, at_height: Option<u64>) -> ChainResult<u32> {
         // /modules/mailbox/state/nonce
         let query = match at_height {
-            Some(0) | None => "/modules/mailbox/nonce",
-            Some(slot) => {
-                &format!("/modules/mailbox/nonce?rollup_height={slot}")
-            }
+            None => "/modules/mailbox/nonce",
+            Some(slot) => &format!("/modules/mailbox/nonce?rollup_height={slot}"),
         };
 
         let response = self
@@ -766,7 +764,7 @@ impl SovereignRestClient {
     }
 
     // @Merkle Tree Hook
-    pub async fn tree(&self, slot: Option<u32>) -> ChainResult<IncrementalMerkle> {
+    pub async fn tree(&self, slot: Option<u64>) -> ChainResult<IncrementalMerkle> {
         #[derive(Clone, Debug, Deserialize)]
         struct Inner {
             count: usize,
@@ -780,7 +778,7 @@ impl SovereignRestClient {
         // /modules/merkle-tree-hook/state/tree
         // todo: this seems wrong
         let query = match slot {
-            Some(0) | None => "modules/merkle-tree-hook/tree".into(),
+            None => "modules/merkle-tree-hook/tree".into(),
             Some(slot) => {
                 format!("modules/merkle-tree-hook/tree?rollup_height={slot}")
             }
@@ -822,7 +820,7 @@ impl SovereignRestClient {
     pub async fn latest_checkpoint(
         &self,
         hook_id: &str,
-        lag: Option<u32>,
+        lag: Option<u64>,
         mailbox_domain: u32,
     ) -> ChainResult<Checkpoint> {
         #[derive(Clone, Debug, Deserialize)]
@@ -833,11 +831,13 @@ impl SovereignRestClient {
 
         // /mailbox-hook-merkle-tree/{hook_id}/checkpoint
         let query = match lag {
-            Some(0) | None => {
+            None => {
                 format!("modules/mailbox-hook-merkle-tree/{hook_id}/checkpoint")
             }
             Some(slot) => {
-                format!("modules/mailbox-hook-merkle-tree/{hook_id}/checkpoint?rollup_height={slot}")
+                format!(
+                    "modules/mailbox-hook-merkle-tree/{hook_id}/checkpoint?rollup_height={slot}"
+                )
             }
         };
 

--- a/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
@@ -392,14 +392,6 @@ impl SovereignRestClient {
         })
     }
 
-    // todo: this seems wrong
-    async fn get_compensated_rollup_height(&self, lag: u64) -> ChainResult<u64> {
-        let current_slot = self.get_latest_slot().await?;
-        current_slot.checked_sub(lag).ok_or_else(|| {
-            ChainCommunicationError::CustomError("lag was greater than rollup height".to_string())
-        })
-    }
-
     // Return the latest slot.
     pub async fn get_latest_slot(&self) -> ChainResult<u64> {
         #[derive(Clone, Debug, Deserialize)]
@@ -468,12 +460,10 @@ impl SovereignRestClient {
     // @Mailbox
     pub async fn get_count(&self, at_height: Option<u32>) -> ChainResult<u32> {
         // /modules/mailbox/state/nonce
-        // todo: this seems wrong
         let query = match at_height {
             Some(0) | None => "/modules/mailbox/nonce",
-            Some(lag) => {
-                let rollup_height = self.get_compensated_rollup_height(u64::from(lag)).await?;
-                &format!("/modules/mailbox/nonce?rollup_height={rollup_height}")
+            Some(slot) => {
+                &format!("/modules/mailbox/nonce?rollup_height={slot}")
             }
         };
 
@@ -790,10 +780,9 @@ impl SovereignRestClient {
         // /modules/merkle-tree-hook/state/tree
         // todo: this seems wrong
         let query = match slot {
-            Some(0) | None => "modules/merkle-tree-hook/state/tree".into(),
-            Some(lag) => {
-                let rollup_height = self.get_compensated_rollup_height(u64::from(lag)).await?;
-                format!("modules/merkle-tree-hook/state/tree?rollup_height={rollup_height}")
+            Some(0) | None => "modules/merkle-tree-hook/tree".into(),
+            Some(slot) => {
+                format!("modules/merkle-tree-hook/tree?rollup_height={slot}")
             }
         };
 
@@ -847,10 +836,8 @@ impl SovereignRestClient {
             Some(0) | None => {
                 format!("modules/mailbox-hook-merkle-tree/{hook_id}/checkpoint")
             }
-            Some(lag) => {
-                // todo: this seems wrong
-                let rollup_height = self.get_compensated_rollup_height(u64::from(lag)).await?;
-                format!("modules/mailbox-hook-merkle-tree/{hook_id}/checkpoint?rollup_height={rollup_height}")
+            Some(slot) => {
+                format!("modules/mailbox-hook-merkle-tree/{hook_id}/checkpoint?rollup_height={slot}")
             }
         };
 

--- a/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
@@ -412,7 +412,7 @@ impl SovereignRestClient {
     }
 
     // Return the finalized slot
-    pub async fn get_finalized_slot(&self) -> ChainResult<Option<u64>> {
+    pub async fn get_finalized_slot(&self) -> ChainResult<u64> {
         #[derive(Clone, Debug, Deserialize)]
         struct Data {
             number: u64,
@@ -428,7 +428,7 @@ impl SovereignRestClient {
             "Invalid response".to_string(),
         ))?;
 
-        Ok(Some(data.number))
+        Ok(data.number)
     }
 
     // @Provider
@@ -776,11 +776,10 @@ impl SovereignRestClient {
         }
 
         // /modules/merkle-tree-hook/state/tree
-        // todo: this seems wrong
         let query = match slot {
-            None => "modules/merkle-tree-hook/tree".into(),
+            None => "modules/merkle-tree-hook/state/tree".into(),
             Some(slot) => {
-                format!("modules/merkle-tree-hook/tree?rollup_height={slot}")
+                format!("modules/merkle-tree-hook/state/tree?slot_number={slot}")
             }
         };
 

--- a/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
@@ -412,7 +412,7 @@ impl SovereignRestClient {
     }
 
     // Return the finalized slot
-    pub async fn get_finalized_slot(&self) -> ChainResult<u64> {
+    pub async fn get_finalized_slot(&self) -> ChainResult<Option<u64>> {
         #[derive(Clone, Debug, Deserialize)]
         struct Data {
             number: u64,
@@ -428,7 +428,7 @@ impl SovereignRestClient {
             "Invalid response".to_string(),
         ))?;
 
-        Ok(data.number)
+        Ok(Some(data.number))
     }
 
     // @Provider
@@ -462,7 +462,7 @@ impl SovereignRestClient {
         // /modules/mailbox/state/nonce
         let query = match at_height {
             None => "/modules/mailbox/nonce",
-            Some(slot) => &format!("/modules/mailbox/nonce?rollup_height={slot}"),
+            Some(slot) => &format!("/modules/mailbox/nonce?slot_number={slot}"),
         };
 
         let response = self
@@ -820,7 +820,7 @@ impl SovereignRestClient {
     pub async fn latest_checkpoint(
         &self,
         hook_id: &str,
-        lag: Option<u64>,
+        at_height: Option<u64>,
         mailbox_domain: u32,
     ) -> ChainResult<Checkpoint> {
         #[derive(Clone, Debug, Deserialize)]
@@ -830,14 +830,12 @@ impl SovereignRestClient {
         }
 
         // /mailbox-hook-merkle-tree/{hook_id}/checkpoint
-        let query = match lag {
+        let query = match at_height {
             None => {
                 format!("modules/mailbox-hook-merkle-tree/{hook_id}/checkpoint")
             }
             Some(slot) => {
-                format!(
-                    "modules/mailbox-hook-merkle-tree/{hook_id}/checkpoint?rollup_height={slot}"
-                )
+                format!("modules/mailbox-hook-merkle-tree/{hook_id}/checkpoint?slot_number={slot}")
             }
         };
 


### PR DESCRIPTION
### Description

Fix upstream endpoints and use correct slot numbers in indexers.

### Drive-by changes

No

### Related issues

https://github.com/Sovereign-Labs/sovereign-sdk-wip/pull/2720

### Backward compatibility

Yes

### Testing

Successfully ran with sov e2e.
