### PR TITLE
chore: Update toml files to remove warnings

### DIFF
--- a/rust/main/hyperlane-core/Cargo.toml
+++ b/rust/main/hyperlane-core/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "hyperlane-core"
 documentation = { workspace = true }

--- a/rust/sealevel/libraries/account-utils/Cargo.toml
+++ b/rust/sealevel/libraries/account-utils/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "account-utils"
 version = "0.1.0"

--- a/rust/sealevel/libraries/interchain-security-module-interface/Cargo.toml
+++ b/rust/sealevel/libraries/interchain-security-module-interface/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "hyperlane-sealevel-interchain-security-module-interface"
 version = "0.1.0"

--- a/rust/sealevel/libraries/message-recipient-interface/Cargo.toml
+++ b/rust/sealevel/libraries/message-recipient-interface/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "hyperlane-sealevel-message-recipient-interface"
 version = "0.1.0"

--- a/rust/sealevel/libraries/multisig-ism/Cargo.toml
+++ b/rust/sealevel/libraries/multisig-ism/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "multisig-ism"
 version = "0.1.0"

--- a/rust/sealevel/libraries/serializable-account-meta/Cargo.toml
+++ b/rust/sealevel/libraries/serializable-account-meta/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "serializable-account-meta"
 version = "0.1.0"

--- a/rust/sealevel/programs/hyperlane-sealevel-igp/Cargo.toml
+++ b/rust/sealevel/programs/hyperlane-sealevel-igp/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "hyperlane-sealevel-igp"
 version = "0.1.0"

--- a/rust/sealevel/programs/ism/multisig-ism-message-id/Cargo.toml
+++ b/rust/sealevel/programs/ism/multisig-ism-message-id/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "hyperlane-sealevel-multisig-ism-message-id"
 version = "0.1.0"

--- a/rust/sealevel/programs/mailbox/Cargo.toml
+++ b/rust/sealevel/programs/mailbox/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "hyperlane-sealevel-mailbox"
 version = "0.1.0"

--- a/rust/sealevel/programs/validator-announce/Cargo.toml
+++ b/rust/sealevel/programs/validator-announce/Cargo.toml
@@ -1,5 +1,3 @@
-cargo-features = ["workspace-inheritance"]
-
 [package]
 name = "hyperlane-sealevel-validator-announce"
 version = "0.1.0"


### PR DESCRIPTION
### Description

Update toml's to remove `cargo c` warnings.

### Drive-by changes

No

### Related issues

NA

### Backward compatibility

Yes

### Testing

Manual
