### PR TITLE
chore: Replace Strings with less-general types

### DIFF
--- a/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/merkle_tree_hook.rs
@@ -12,7 +12,6 @@ use hyperlane_core::{
     SequenceAwareIndexer, H256, H512,
 };
 use serde::Deserialize;
-use std::str::FromStr;
 
 /// Struct that retrieves event data for a Sovereign Mailbox contract.
 #[derive(Debug, Clone)]
@@ -52,7 +51,7 @@ impl crate::indexer::SovIndexer<MerkleTreeInsertion> for SovereignMerkleTreeHook
 
         let merkle_insertion = MerkleTreeInsertion::new(
             parsed_event.inserted_into_tree.index,
-            H256::from_str(&parsed_event.inserted_into_tree.id)?,
+            parsed_event.inserted_into_tree.id,
         );
 
         Ok(merkle_insertion)
@@ -66,7 +65,7 @@ struct InsertedIntoTreeEvent {
 
 #[derive(Clone, Debug, Deserialize)]
 struct TreeEventBody {
-    id: String,
+    id: H256,
     index: u32,
 }
 

--- a/rust/main/chains/hyperlane-sovereign/src/universal_wallet_client/tx_state.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/universal_wallet_client/tx_state.rs
@@ -2,6 +2,7 @@ pub type WsSubscription<T> = Result<BoxStream<'static, anyhow::Result<T>>, WsErr
 use crate::universal_wallet_client::UniversalClient;
 use futures::stream::BoxStream;
 use futures::StreamExt;
+use hyperlane_core::H256;
 use tokio_tungstenite::connect_async;
 use tokio_tungstenite::tungstenite::{Error as WsError, Message};
 
@@ -9,9 +10,9 @@ impl UniversalClient {
     /// Subscribe to a websocket for status updates.
     pub async fn subscribe_to_tx_status_updates(
         &self,
-        tx_hash: String,
+        tx_hash: H256,
     ) -> WsSubscription<crate::universal_wallet_client::types::TxInfo> {
-        self.subscribe_to_ws(&format!("/sequencer/txs/{tx_hash}/ws"))
+        self.subscribe_to_ws(&format!("/sequencer/txs/{tx_hash:?}/ws"))
             .await
     }
 

--- a/rust/main/chains/hyperlane-sovereign/src/universal_wallet_client/utils.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/universal_wallet_client/utils.rs
@@ -1,6 +1,6 @@
 use crate::universal_wallet_client::{crypto, UniversalClient};
 use hyperlane_core::{
-    Announcement, ChainCommunicationError, ChainResult, Encode, HyperlaneMessage, SignedType,
+    Announcement, ChainCommunicationError, ChainResult, Encode, HyperlaneMessage, SignedType, H256,
 };
 use serde_json::{json, Value};
 use std::env;
@@ -91,7 +91,7 @@ pub async fn get_simulate_json_query(
 pub async fn announce_validator(
     announcement: SignedType<Announcement>,
     client: &UniversalClient,
-) -> ChainResult<String> {
+) -> ChainResult<H256> {
     let sig_hyperlane = announcement.signature;
     let sig_bytes: [u8; 65] = sig_hyperlane.into();
     let call_message = json!({


### PR DESCRIPTION
### Description

Use more specific fields types in structs, i.e. replace `String` with `H256` or other suitable type where appropriate. 

### Drive-by changes

No

### Related issues

https://github.com/eigerco/hyperlane-monorepo/pull/56

### Backward compatibility

Yes

### Testing

Manual
