### PR TITLE
chore: Use into() not from() for error formatting

### DIFF
--- a/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/rest_client.rs
@@ -427,7 +427,7 @@ impl SovereignRestClient {
                 .gas_price
                 .first()
                 .ok_or_else(|| {
-                    ChainCommunicationError::CustomError(String::from("Failed to get item(0)"))
+                    ChainCommunicationError::CustomError("Failed to get item(0)".into())
                 })?
                 .parse::<u32>()
                 .map_err(|e| {
@@ -445,7 +445,7 @@ impl SovereignRestClient {
                 .base_fee
                 .first()
                 .ok_or_else(|| {
-                    ChainCommunicationError::CustomError(String::from("Failed to get item(0)"))
+                    ChainCommunicationError::CustomError("Failed to get item(0)".into())
                 })?,
         );
 


### PR DESCRIPTION
### Description

nit. replace `String::from()` with `into()` for chain error messages.

### Drive-by changes

No

### Related issues

https://github.com/eigerco/hyperlane-monorepo/pull/56

### Backward compatibility

Yes

### Testing

manual
