### PR TITLE
fix: build local hyperlane-cli in docker image

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -8,6 +8,11 @@ set -xeuo pipefail
 # cd to script's dir
 cd -- "$(dirname -- "${BASH_SOURCE[0]}")"
 
+# this script should be a single command to build hyperlane image for
+# usage within sovereign-sdk, so make sure no one forgets about this
+# step
+git submodule update --init --recursive
+
 # hyperlane has git based dependency on sov, so we need to
 # transfer authorized keys to the builder
 eval "$(ssh-agent -s)"

--- a/hyperlane.Dockerfile
+++ b/hyperlane.Dockerfile
@@ -35,27 +35,29 @@ FROM debian:bookworm-slim AS runner
 
 WORKDIR /build
 
-# build and install @hyperlane-xyz/cli
-# TODO: this clones branch that is much more up to date with
-# upstream hyperlane-monorepo than the branch with rust components.
-# This should be replaced with `COPY` as rust gets up to date with upstream.
+COPY *.json yarn.lock .yarnrc.yml .*rc ./
+COPY .yarn ./.yarn
+COPY typescript ./typescript
+COPY solidity ./solidity
+COPY starknet ./starknet
+
 RUN apt-get update && \
-  apt-get install -y --no-install-recommends git libclang-dev npm jq make build-essential && \
+  apt-get install -y --no-install-recommends curl libclang-dev npm jq make build-essential unzip && \
   npm install -g yarn && \
-  git clone https://github.com/eigerco/hyperlane-monorepo --depth 1 --branch sovereign-cli-support && \
-  cd hyperlane-monorepo && \
+  yarn set version 4.5.1 && \
   yarn install && \
   yarn build && \
   yarn workspace @hyperlane-xyz/cli bundle && \
   npm install -g ./typescript/cli && \
-  apt-get remove --purge -y git jq make build-essential && \
+  yarn cache clean && \
+  apt-get remove --purge -y curl jq make build-essential unzip && \
   apt-get autoremove -y && \
   apt-get clean && \
   rm -rf /var/lib/apt/lists/* && \
   npm uninstall -g yarn && \
   npm cache clear --force && \
   cd - && \
-  rm -rf hyperlane-monorepo
+  rm -rf build
 
 WORKDIR /app
 


### PR DESCRIPTION
### Description

Previously, when rust side was out of date, we used to build a hyperlane cli from a more up to date branch. This reverts that behavior and uses local hyperlane cli build in docker image.

