### PR TITLE
Update REST API types for Sovereign rollups

### DIFF
--- a/.github/workflows/sov-sdk-testing-docker.yml
+++ b/.github/workflows/sov-sdk-testing-docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 # Automatically cancels a job if a new commit is pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>
@@ -73,7 +74,7 @@ jobs:
           file: ./hyperlane.Dockerfile
           push: true
           # todo: tag with refs on pull requests
-          tags: ghcr.io/${{ github.repository_owner }}/hyperlane:latest-${{ matrix.platform.arch }}
+          tags: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-${{ matrix.platform.arch }}
           ssh: default=${{ runner.temp }}/.ssh/id_rsa
           cache-from: type=local,src=${{ runner.temp }}/.buildx-cache-${{ matrix.platform.arch }}
           cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new
@@ -101,6 +102,6 @@ jobs:
       - name: Create and push manifest images
         uses: Noelware/docker-manifest-action@0.4.3
         with:
-          inputs: ghcr.io/${{ github.repository_owner }}/hyperlane:latest
-          images: ghcr.io/${{ github.repository_owner }}/hyperlane:latest-amd64,ghcr.io/${{ github.repository_owner }}/hyperlane:latest-arm64
+          inputs: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}
+          images: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-amd64,ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-arm64
           push: true

--- a/.github/workflows/sov-sdk-testing-docker.yml
+++ b/.github/workflows/sov-sdk-testing-docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 # Automatically cancels a job if a new commit is pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>
@@ -74,7 +73,7 @@ jobs:
           file: ./hyperlane.Dockerfile
           push: true
           # todo: tag with refs on pull requests
-          tags: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-${{ matrix.platform.arch }}
+          tags: ghcr.io/${{ github.repository_owner }}/hyperlane:latest-${{ matrix.platform.arch }}
           ssh: default=${{ runner.temp }}/.ssh/id_rsa
           cache-from: type=local,src=${{ runner.temp }}/.buildx-cache-${{ matrix.platform.arch }}
           cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new
@@ -102,6 +101,6 @@ jobs:
       - name: Create and push manifest images
         uses: Noelware/docker-manifest-action@0.4.3
         with:
-          inputs: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}
-          images: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-amd64,ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-arm64
+          inputs: ghcr.io/${{ github.repository_owner }}/hyperlane:latest
+          images: ghcr.io/${{ github.repository_owner }}/hyperlane:latest-amd64,ghcr.io/${{ github.repository_owner }}/hyperlane:latest-arm64
           push: true

--- a/rust/main/chains/hyperlane-sovereign/src/provider/client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/client.rs
@@ -13,14 +13,6 @@ use url::Url;
 
 use crate::{ConnectionConf, Signer};
 
-/// A generic rollup rest response
-#[derive(Clone, Debug, Deserialize)]
-struct RestResponse<T> {
-    data: Option<T>,
-    #[serde(default)]
-    errors: Vec<ErrorInfo>,
-}
-
 /// Request error details
 #[derive(Clone, Deserialize)]
 pub(crate) struct ErrorInfo {
@@ -47,7 +39,7 @@ impl fmt::Debug for ErrorInfo {
 /// between those cases and checking the status code of the response.
 #[derive(Debug)]
 pub(crate) enum RestClientError {
-    Response(StatusCode, Vec<ErrorInfo>),
+    Response(StatusCode, ErrorInfo),
     Other(String),
 }
 
@@ -136,14 +128,13 @@ impl SovereignClient {
 fn is_retryable(err: &RestClientError) -> bool {
     match err {
         // TODO: make this more robust, handle rate limiting, etc
-        RestClientError::Response(status_code, errs) => {
+        RestClientError::Response(status_code, err) => {
             if status_code.is_server_error() {
                 true
             } else {
                 // Handle bug on rollup side where queryable slot_number
                 // can lag behind `/ledger/slots/finalized`
-                errs.iter()
-                    .any(|err| err.title.contains("invalid rollup height"))
+                err.title.contains("invalid rollup height")
             }
         }
         RestClientError::Other(_) => false,
@@ -216,16 +207,17 @@ where
     T: Debug + for<'a> Deserialize<'a>,
 {
     let status = response.status();
-    let result: RestResponse<T> = response
-        .json()
-        .await
-        .map_err(|e| RestClientError::Other(format!("{e:?}")))?;
 
     if status.is_success() {
-        result
-            .data
-            .ok_or_else(|| RestClientError::Other("Missing data in response".into()))
+        Ok(response
+            .json()
+            .await
+            .map_err(|e| RestClientError::Other(format!("{e:?}")))?)
     } else {
-        Err(RestClientError::Response(status, result.errors))
+        let err = response
+            .json()
+            .await
+            .map_err(|e| RestClientError::Other(format!("{e:?}")))?;
+        Err(RestClientError::Response(status, err))
     }
 }

--- a/rust/main/chains/hyperlane-sovereign/src/provider/client.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/client.rs
@@ -16,7 +16,7 @@ use crate::{ConnectionConf, Signer};
 /// Request error details
 #[derive(Clone, Deserialize)]
 pub(crate) struct ErrorInfo {
-    title: String,
+    message: String,
     status: u64,
     details: Value,
 }
@@ -29,7 +29,7 @@ impl fmt::Debug for ErrorInfo {
                 details = format!(": {json}");
             }
         }
-        write!(f, "'{} ({}){}'", self.title, self.status, details)
+        write!(f, "'{} ({}){}'", self.message, self.status, details)
     }
 }
 
@@ -134,7 +134,7 @@ fn is_retryable(err: &RestClientError) -> bool {
             } else {
                 // Handle bug on rollup side where queryable slot_number
                 // can lag behind `/ledger/slots/finalized`
-                err.title.contains("invalid rollup height")
+                err.message.contains("invalid rollup height")
             }
         }
         RestClientError::Other(_) => false,


### PR DESCRIPTION
### Description

Updates REST API types for Sovereign rollups. We no longer have the `RestResponse` wrapper object and a couple of endpoint responses changed slightly

