### PR TITLE
feat: implement ethereum based crypto scheme and runtime fallbacks

### DIFF
--- a/.github/workflows/sov-sdk-testing-docker.yml
+++ b/.github/workflows/sov-sdk-testing-docker.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - main
+  pull_request:
 
 # Automatically cancels a job if a new commit is pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>
@@ -73,7 +74,7 @@ jobs:
           file: ./hyperlane.Dockerfile
           push: true
           # todo: tag with refs on pull requests
-          tags: ghcr.io/${{ github.repository_owner }}/hyperlane:latest-${{ matrix.platform.arch }}
+          tags: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-${{ matrix.platform.arch }}
           ssh: default=${{ runner.temp }}/.ssh/id_rsa
           cache-from: type=local,src=${{ runner.temp }}/.buildx-cache-${{ matrix.platform.arch }}
           cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new
@@ -101,6 +102,6 @@ jobs:
       - name: Create and push manifest images
         uses: Noelware/docker-manifest-action@0.4.3
         with:
-          inputs: ghcr.io/${{ github.repository_owner }}/hyperlane:latest
-          images: ghcr.io/${{ github.repository_owner }}/hyperlane:latest-amd64,ghcr.io/${{ github.repository_owner }}/hyperlane:latest-arm64
+          inputs: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}
+          images: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-amd64,ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-arm64
           push: true

--- a/.github/workflows/sov-sdk-testing-docker.yml
+++ b/.github/workflows/sov-sdk-testing-docker.yml
@@ -4,7 +4,6 @@ on:
   push:
     branches:
       - main
-  pull_request:
 
 # Automatically cancels a job if a new commit is pushed to the same PR, branch, or tag.
 # Source: <https://stackoverflow.com/a/72408109/5148606>
@@ -74,7 +73,7 @@ jobs:
           file: ./hyperlane.Dockerfile
           push: true
           # todo: tag with refs on pull requests
-          tags: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-${{ matrix.platform.arch }}
+          tags: ghcr.io/${{ github.repository_owner }}/hyperlane:latest-${{ matrix.platform.arch }}
           ssh: default=${{ runner.temp }}/.ssh/id_rsa
           cache-from: type=local,src=${{ runner.temp }}/.buildx-cache-${{ matrix.platform.arch }}
           cache-to: type=local,dest=${{ runner.temp }}/.buildx-cache-new
@@ -102,6 +101,6 @@ jobs:
       - name: Create and push manifest images
         uses: Noelware/docker-manifest-action@0.4.3
         with:
-          inputs: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}
-          images: ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-amd64,ghcr.io/${{ github.repository_owner }}/hyperlane:${{ github.event.pull_request.head.sha }}-arm64
+          inputs: ghcr.io/${{ github.repository_owner }}/hyperlane:latest
+          images: ghcr.io/${{ github.repository_owner }}/hyperlane:latest-amd64,ghcr.io/${{ github.repository_owner }}/hyperlane:latest-arm64
           push: true

--- a/rust/main/Cargo.lock
+++ b/rust/main/Cargo.lock
@@ -10296,7 +10296,7 @@ dependencies = [
 [[package]]
 name = "sov-universal-wallet"
 version = "0.1.0"
-source = "git+ssh://git@github.com/Sovereign-Labs/sovereign-sdk-wip?branch=nightly#f77a56706c6e8939d4e574c07f76d584e943bbf6"
+source = "git+ssh://git@github.com/Sovereign-Labs/sovereign-sdk-wip?branch=nightly#e748973351d75b4e0c8371c4f54d062335d105e3"
 dependencies = [
  "arrayvec",
  "bech32 0.11.0",

--- a/rust/main/chains/hyperlane-sovereign/src/application/mod.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/application/mod.rs
@@ -8,7 +8,7 @@ use hyperlane_operation_verifier::{
 };
 use hyperlane_warp_route::TokenMessage;
 
-use crate::signers::SOV_HEX_ADDRESS_LEADING_ZEROS;
+use crate::signers::ed25519::SOV_HEX_ADDRESS_LEADING_ZEROS;
 
 const WARP_ROUTE_MARKER: &str = "/";
 
@@ -59,6 +59,7 @@ impl ApplicationOperationVerifier for SovereignApplicationOperationVerifier {
     }
 }
 
+// this uses the ed25519 addresses check as it has less leading zeros
 fn has_enough_leading_zeroes(address: H256) -> bool {
     address
         .as_bytes()

--- a/rust/main/chains/hyperlane-sovereign/src/provider/methods.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/provider/methods.rs
@@ -12,7 +12,9 @@ use serde::Deserialize;
 use serde_json::json;
 
 use super::client::SovereignClient;
+use crate::provider::client::RestClientError;
 use crate::types::{Batch, Slot, Tx};
+use crate::Crypto;
 
 impl SovereignClient {
     /// Get the batch by number
@@ -177,21 +179,33 @@ impl SovereignClient {
         });
 
         let encoded_call_message = self.encoded_call_message(&call_message)?;
-        let json = json!({
-            "body": {
-              "details":{
-                "chain_id": message.destination,
-                "max_fee": "100000000",
-                "max_priority_fee_bips": 0
-              },
-              "encoded_call_message": encoded_call_message,
-              "nonce": message.nonce,
-              "generation": 0,
-              "sender_pub_key": "\"f8ad2437a279e1c8932c07358c91dc4fe34864a98c6c25f298e2a0199c1509ff\""
-            }
-        });
+        let request_json = |public_key| {
+            json!({
+                "body": {
+                  "details":{
+                    "chain_id": message.destination,
+                    "max_fee": "100000000",
+                    "max_priority_fee_bips": 0
+                  },
+                  "encoded_call_message": &encoded_call_message,
+                  "nonce": message.nonce,
+                  "generation": 0,
+                  "sender_pub_key": format!("\"{}\"", hex::encode(public_key))
+                }
+            })
+        };
 
-        let response = self.http_post::<Data>(query, &json).await?;
+        let ed25519_request = request_json(self.signer.ed25519().public_key());
+        let response = match self.http_post::<Data>(query, &ed25519_request).await {
+            Err(error @ RestClientError::Response(..))
+                if error.to_string().contains("Invalid public key size") =>
+            {
+                let eth_request = request_json(self.signer.ethereum().public_key());
+                self.http_post::<Data>(query, &eth_request).await?
+            }
+
+            res => res?,
+        };
 
         let receipt = response.apply_tx_result.receipt;
         if receipt.receipt.outcome != "successful" {

--- a/rust/main/chains/hyperlane-sovereign/src/signers.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers.rs
@@ -59,10 +59,12 @@ impl Signer {
         })
     }
 
+    /// An ethereum based signer
     pub fn ethereum(&self) -> &impl Crypto {
         &self.ethereum
     }
 
+    /// An edward based signer
     pub fn ed25519(&self) -> &impl Crypto {
         &self.ed25519
     }

--- a/rust/main/chains/hyperlane-sovereign/src/signers.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers.rs
@@ -1,34 +1,70 @@
+//! Cryptographic primitives for sovereign rollups.
+//!
+//! Each sovereign rollup can use a custom cryptographic scheme,
+//! but at the same time there is no API that provides information what scheme is used.
+//!
+//! This means that there is no way to tell how messages should be signed, in what format
+//! should the public key be provided, or how to derive address from the public key.
+//!
+//! Currently there are two implementations in use:
+//! - ed25519 based
+//! - ethereum based
+//!
+//! and the only way to check which one rollup uses is to try them all and see which one
+//! achieves a successful response from the rollup.
+//!
+//! In a future, the `Schema` from `sov-universal-wallet` may contain the necessary information
+//! to choose the correct implementation during the runtime, however it's not available yet, and
+//! not planned for a foreseeable future.
+
 use std::env;
 
-use bech32::{Bech32m, Hrp};
-use ed25519_dalek::{Signature, Signer as _, SigningKey, VerifyingKey};
-use hyperlane_core::{ChainResult, H256};
+use hyperlane_core::{ChainCommunicationError, ChainResult, H256};
 use tokio::fs;
 use tracing::warn;
 
-/// Length of the sovereign address in bytes
-pub const SOV_ADDRESS_LENGTH: usize = 28;
-/// Amount of leading zeros padding in hex address representation.
-pub const SOV_HEX_ADDRESS_LEADING_ZEROS: usize = 4;
+pub mod ed25519;
+pub mod ethereum;
+
+/// Common methods for signers
+pub trait Crypto {
+    /// Sign provided message and return signature's bytes
+    fn sign(&self, bytes: impl AsRef<[u8]>) -> ChainResult<Vec<u8>>;
+
+    /// Get public key bytes
+    fn public_key(&self) -> Vec<u8>;
+
+    /// Get the address is rollup's format
+    fn address(&self) -> ChainResult<String>;
+
+    /// Get the address in hyperlane format
+    fn h256_address(&self) -> H256;
+}
 
 /// Signer for Sovereign chain.
 #[derive(Clone, Debug)]
 pub struct Signer {
-    /// Private key
-    private_key: SigningKey,
-    /// Precomputed address, as the operation is fallible.
-    address: String,
+    /// ethereum crypto implementation
+    ethereum: ethereum::Signer,
+    /// ed25519 crypto implementation
+    ed25519: ed25519::Signer,
 }
 
 impl Signer {
     /// Create a new Sovereign signer.
     pub fn new(private_key: &H256) -> ChainResult<Self> {
-        let private_key = private_key.as_fixed_bytes().into();
-        let address = address_from_sk(&private_key)?;
         Ok(Signer {
-            address,
-            private_key,
+            ethereum: ethereum::Signer::new(private_key)?,
+            ed25519: ed25519::Signer::new(private_key)?,
         })
+    }
+
+    pub fn ethereum(&self) -> &impl Crypto {
+        &self.ethereum
+    }
+
+    pub fn ed25519(&self) -> &impl Crypto {
+        &self.ed25519
     }
 
     /// Get the key for sovereign signer if it was provided using `TOKEN_KEY_FILE` env var.
@@ -45,72 +81,15 @@ impl Signer {
 
         warn!("Getting sovereign key from {key_file}; this behaviour is deprecated and will be removed");
 
-        let data = fs::read_to_string(&key_file)
-            .await
-            .map_err(|e| custom_err!("Failed to read file at {key_file}: {e:?}"))?;
+        let data = fs::read_to_string(&key_file).await.map_err(|e| {
+            ChainCommunicationError::CustomError(format!(
+                "Failed to read file at {key_file}: {e:?}"
+            ))
+        })?;
         let outer_value: serde_json::Value = serde_json::from_str(&data)?;
         let inner_value = outer_value["private_key"]["key_pair"].clone();
         let bytes: [u8; 32] = serde_json::from_value(inner_value)?;
 
         Ok(Some(H256(bytes)))
-    }
-
-    /// Produce signature for the hash of the input
-    pub fn sign(&self, input: impl AsRef<[u8]>) -> Signature {
-        self.private_key.sign(input.as_ref())
-    }
-
-    /// Get the public key
-    pub fn public_key(&self) -> &VerifyingKey {
-        self.private_key.as_ref()
-    }
-
-    /// Get the address as `bech32` string
-    pub fn address(&self) -> &str {
-        &self.address
-    }
-
-    /// Get the address as [`H256`] padded with 0's from the left
-    pub fn h256_address(&self) -> H256 {
-        let mut h256 = H256::zero();
-        h256[SOV_HEX_ADDRESS_LEADING_ZEROS..]
-            .copy_from_slice(&self.public_key().to_bytes()[..SOV_ADDRESS_LENGTH]);
-        h256
-    }
-}
-
-fn address_from_sk(private_key: &SigningKey) -> ChainResult<String> {
-    // Sov address uses first 28 bytes of the public key
-    // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/blob/fdad6aef490656ce4ad6c93f486569acb71d11eb/crates/module-system/sov-modules-api/src/common/address.rs#L411-L415>
-    // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/blob/fdad6aef490656ce4ad6c93f486569acb71d11eb/crates/module-system/sov-modules-api/src/common/address.rs#L365-L369>
-    let hrp = Hrp::parse("sov").expect("valid hrp");
-    let public_key = private_key.verifying_key();
-    let address = bech32::encode::<Bech32m>(hrp, &public_key.as_bytes()[..SOV_ADDRESS_LENGTH])
-        .map_err(|e| custom_err!("Encoding public key to bech32 failed: {e}"))?;
-
-    Ok(address)
-}
-
-#[cfg(test)]
-mod test {
-    use super::*;
-
-    #[test]
-    fn test_address_from_h256() {
-        // values from <https://github.com/Sovereign-Labs/sov-rollup-starter-wip/blob/94ce661edb1dcc338bc4b7232b8fe8632e7540c5/test-data/keys/token_deployer_private_key.json>
-        let private_key = H256([
-            117, 251, 248, 217, 135, 70, 194, 105, 46, 80, 41, 66, 185, 56, 200, 35, 121, 253, 9,
-            234, 159, 91, 96, 212, 211, 158, 135, 225, 180, 36, 104, 253,
-        ]);
-        let signer = Signer::new(&private_key).unwrap();
-
-        assert_eq!(
-            "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
-            signer.address()
-        );
-        assert_eq!(
-            "0x00000000f8ad2437a279e1c8932c07358c91dc4fe34864a98c6c25f298e2a019",
-            format!("{:?}", signer.h256_address()),
-        );
     }
 }

--- a/rust/main/chains/hyperlane-sovereign/src/signers/ed25519.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers/ed25519.rs
@@ -1,0 +1,83 @@
+//! Ed25519 based crypto scheme used in sovereign. This is the default one used e.g. in `TestSpec`.
+
+use bech32::{Bech32m, Hrp};
+use ed25519_dalek::{Signer as _, SigningKey};
+use hyperlane_core::{ChainCommunicationError, ChainResult, H256};
+
+use crate::signers::Crypto;
+
+/// Length of the sovereign address in bytes
+pub const SOV_ADDRESS_LENGTH: usize = 28;
+/// Amount of leading zeros padding in hex address representation.
+pub const SOV_HEX_ADDRESS_LEADING_ZEROS: usize = 4;
+
+/// Signer for Sovereign chain.
+#[derive(Clone, Debug)]
+pub struct Signer(SigningKey);
+
+impl Signer {
+    /// Create a new Sovereign ed25519 signer.
+    pub fn new(private_key: &H256) -> ChainResult<Self> {
+        let private_key = private_key.as_fixed_bytes().into();
+        Ok(Signer(private_key))
+    }
+}
+
+impl Crypto for Signer {
+    fn sign(&self, bytes: impl AsRef<[u8]>) -> ChainResult<Vec<u8>> {
+        Ok(self.0.sign(bytes.as_ref()).to_bytes().to_vec())
+    }
+
+    fn public_key(&self) -> Vec<u8> {
+        self.0.verifying_key().as_bytes().to_vec()
+    }
+
+    fn address(&self) -> ChainResult<String> {
+        // Sov address uses first 28 bytes of the public key
+        // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/blob/fdad6aef490656ce4ad6c93f486569acb71d11eb/crates/module-system/sov-modules-api/src/common/address.rs#L411-L415>
+        // <https://github.com/Sovereign-Labs/sovereign-sdk-wip/blob/fdad6aef490656ce4ad6c93f486569acb71d11eb/crates/module-system/sov-modules-api/src/common/address.rs#L365-L369>
+        let hrp = Hrp::parse("sov").expect("valid hrp");
+        let address = bech32::encode::<Bech32m>(
+            hrp,
+            &self.0.verifying_key().as_bytes()[..SOV_ADDRESS_LENGTH],
+        )
+        .map_err(|e| {
+            ChainCommunicationError::CustomError(format!(
+                "Encoding public key to bech32 failed: {e}"
+            ))
+        })?;
+
+        Ok(address)
+    }
+
+    fn h256_address(&self) -> H256 {
+        let mut h256 = H256::zero();
+        h256[SOV_HEX_ADDRESS_LEADING_ZEROS..]
+            .copy_from_slice(&self.0.verifying_key().to_bytes()[..SOV_ADDRESS_LENGTH]);
+        h256
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_address_from_h256() {
+        // values from <https://github.com/Sovereign-Labs/sov-rollup-starter-wip/blob/94ce661edb1dcc338bc4b7232b8fe8632e7540c5/test-data/keys/token_deployer_private_key.json>
+        let private_key = H256([
+            117, 251, 248, 217, 135, 70, 194, 105, 46, 80, 41, 66, 185, 56, 200, 35, 121, 253, 9,
+            234, 159, 91, 96, 212, 211, 158, 135, 225, 180, 36, 104, 253,
+        ]);
+        let signer = Signer::new(&private_key).unwrap();
+
+        assert_eq!(
+            "sov1lzkjgdaz08su3yevqu6ceywufl35se9f33kztu5cu2spja5hyyf",
+            signer.address().unwrap()
+        );
+        assert_eq!(
+            "0x00000000f8ad2437a279e1c8932c07358c91dc4fe34864a98c6c25f298e2a019",
+            format!("{:?}", signer.h256_address()),
+        );
+    }
+}

--- a/rust/main/chains/hyperlane-sovereign/src/signers/ethereum.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers/ethereum.rs
@@ -1,0 +1,83 @@
+//! Ethereum styled crypto scheme used in sovereign. This one is used in a main example of building
+//! rollup with sovereign, that is in the `sov-rollup-starter`
+
+use hyperlane_core::{ChainResult, H160, H256};
+use k256::ecdsa::SigningKey;
+use sha3::{Digest, Keccak256};
+
+use crate::signers::Crypto;
+
+/// Length of the sovereign address in bytes
+pub const SOV_ADDRESS_LENGTH: usize = 20;
+/// Amount of leading zeros padding in hex address representation.
+pub const SOV_HEX_ADDRESS_LEADING_ZEROS: usize = 12;
+
+/// Signer for Sovereign chain.
+#[derive(Clone, Debug)]
+pub struct Signer(SigningKey);
+
+impl Signer {
+    /// Create a new Sovereign ethereum signer.
+    pub fn new(private_key: &H256) -> ChainResult<Self> {
+        let private_key = SigningKey::from_slice(private_key.as_fixed_bytes().as_slice())
+            .map_err(|e| custom_err!("Failed reading private key: {e}"))?;
+        Ok(Signer(private_key))
+    }
+
+    /// Get the eth style address bytes
+    fn h160_address(&self) -> H160 {
+        let uncompressed = self.0.verifying_key().to_encoded_point(false);
+        let pk_hash = Keccak256::digest(&uncompressed.as_bytes()[1..]);
+
+        let addr: [_; 20] = pk_hash[12..].try_into().expect("Size must be correct");
+        addr.into()
+    }
+}
+
+impl Crypto for Signer {
+    fn sign(&self, bytes: impl AsRef<[u8]>) -> ChainResult<Vec<u8>> {
+        let digest = Keccak256::new_with_prefix(bytes.as_ref());
+
+        self.0
+            .sign_digest_recoverable(digest)
+            .map(|(sig, _)| sig.to_bytes().to_vec())
+            .map_err(|e| custom_err!("Signing failed: {e}"))
+    }
+
+    fn public_key(&self) -> Vec<u8> {
+        let compressed = self.0.verifying_key().to_encoded_point(true);
+        compressed.as_bytes().to_vec()
+    }
+
+    fn address(&self) -> ChainResult<String> {
+        Ok(format!("{:?}", self.h160_address()))
+    }
+
+    fn h256_address(&self) -> H256 {
+        self.h160_address().into()
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn test_address_from_h256() {
+        // values from <https://github.com/Sovereign-Labs/sov-rollup-starter-wip/blob/fd8ccb34ba6133c4c7696d4829f8fd7ac404da19/test-data/keys/token_deployer_private_key.json>
+        let private_key = H256([
+            1, 135, 193, 46, 167, 193, 32, 36, 179, 247, 10, 197, 215, 53, 135, 70, 58, 241, 124,
+            139, 206, 43, 217, 230, 254, 135, 56, 147, 16, 25, 108, 100,
+        ]);
+        let signer = Signer::new(&private_key).unwrap();
+
+        assert_eq!(
+            "0xa6edfca3aa985dd3cc728bffb700933a986ac085",
+            signer.address().unwrap()
+        );
+        assert_eq!(
+            "0x000000000000000000000000a6edfca3aa985dd3cc728bffb700933a986ac085",
+            format!("{:?}", signer.h256_address()),
+        );
+    }
+}

--- a/rust/main/chains/hyperlane-sovereign/src/signers/ethereum.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers/ethereum.rs
@@ -29,7 +29,9 @@ impl Signer {
         let uncompressed = self.0.verifying_key().to_encoded_point(false);
         let pk_hash = Keccak256::digest(&uncompressed.as_bytes()[1..]);
 
-        let addr: [_; 20] = pk_hash[12..].try_into().expect("Size must be correct");
+        let addr: [_; SOV_ADDRESS_LENGTH] = pk_hash[SOV_HEX_ADDRESS_LEADING_ZEROS..]
+            .try_into()
+            .expect("Size must be correct");
         addr.into()
     }
 }

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -2,6 +2,7 @@ use async_trait::async_trait;
 use ethers::prelude::{AwsSigner, LocalWallet};
 use ethers::utils::hex::ToHex;
 use eyre::{bail, Context, Report};
+use hyperlane_sovereign::Crypto as _;
 use rusoto_core::Region;
 use rusoto_kms::KmsClient;
 use tracing::instrument;
@@ -219,13 +220,20 @@ impl BuildableWithSignerConf for hyperlane_sovereign::Signer {
     }
 }
 
+/// We cannot determine if we should use ethereum or ed25519 crypto
+/// impl at this level, so we choose to use an ethereum one, because
+/// it is the one used in sov-rollup-starter
+///
+/// see [`hyperlane_sovereign::signers`] for more info
 impl ChainSigner for hyperlane_sovereign::Signer {
     fn address_string(&self) -> String {
-        self.address().to_owned()
+        self.ethereum()
+            .address()
+            .expect("ethereum address cannot fail")
     }
 
     fn address_h256(&self) -> H256 {
-        self.h256_address()
+        self.ethereum().h256_address()
     }
 }
 


### PR DESCRIPTION
### Description

`sov-rollup-starter-wip` was migrated to use the ethereum based crypto spec. Unfortunately hyperlane cannot get information what spec is used so we need to find out at runtime what spec is used. This implements ethereum spec and runtime fallbacks between the schemes.