### PR TITLE
feat: remove deprecated TOKEN_KEY_FILE variable support

### DIFF
--- a/rust/main/chains/hyperlane-sovereign/src/signers.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers.rs
@@ -68,30 +68,4 @@ impl Signer {
     pub fn ed25519(&self) -> &impl Crypto {
         &self.ed25519
     }
-
-    /// Get the key for sovereign signer if it was provided using `TOKEN_KEY_FILE` env var.
-    ///
-    /// This is kept for backward compatibility of old setups relying on this way of provisioning.
-    /// Should not be relied on otherwise, and `--chains.<sov-rollup-name>.signer.key=<hex>` should be used instead
-    // TODO: delete this after sov side audit is completed / upstream to hyperlane-xyz happens
-    pub async fn get_key_override() -> ChainResult<Option<H256>> {
-        const KEY_FILE_VAR: &str = "TOKEN_KEY_FILE";
-
-        let Ok(key_file) = env::var(KEY_FILE_VAR) else {
-            return Ok(None);
-        };
-
-        warn!("Getting sovereign key from {key_file}; this behaviour is deprecated and will be removed");
-
-        let data = fs::read_to_string(&key_file).await.map_err(|e| {
-            ChainCommunicationError::CustomError(format!(
-                "Failed to read file at {key_file}: {e:?}"
-            ))
-        })?;
-        let outer_value: serde_json::Value = serde_json::from_str(&data)?;
-        let inner_value = outer_value["private_key"]["key_pair"].clone();
-        let bytes: [u8; 32] = serde_json::from_value(inner_value)?;
-
-        Ok(Some(H256(bytes)))
-    }
 }

--- a/rust/main/chains/hyperlane-sovereign/src/signers.rs
+++ b/rust/main/chains/hyperlane-sovereign/src/signers.rs
@@ -17,11 +17,7 @@
 //! to choose the correct implementation during the runtime, however it's not available yet, and
 //! not planned for a foreseeable future.
 
-use std::env;
-
-use hyperlane_core::{ChainCommunicationError, ChainResult, H256};
-use tokio::fs;
-use tracing::warn;
+use hyperlane_core::{ChainResult, H256};
 
 pub mod ed25519;
 pub mod ethereum;

--- a/rust/main/hyperlane-base/src/settings/chains.rs
+++ b/rust/main/hyperlane-base/src/settings/chains.rs
@@ -1136,12 +1136,6 @@ impl ChainConf {
     }
 
     async fn sovereign_signer(&self) -> Result<Option<h_sovereign::Signer>> {
-        // TODO: delete this, see `get_key_override` for more info
-        if let Some(private_key) = h_sovereign::Signer::get_key_override().await? {
-            let signer = h_sovereign::Signer::new(&private_key)?;
-            return Ok(Some(signer));
-        }
-
         self.signer().await
     }
 

--- a/rust/main/hyperlane-base/src/settings/signers.rs
+++ b/rust/main/hyperlane-base/src/settings/signers.rs
@@ -209,10 +209,7 @@ impl ChainSigner for hyperlane_cosmos_native::Signer {
 #[async_trait]
 impl BuildableWithSignerConf for hyperlane_sovereign::Signer {
     async fn build(conf: &SignerConf) -> Result<Self, Report> {
-        // TODO: delete this, see `get_key_override` for more info
-        if let Some(private_key) = hyperlane_sovereign::Signer::get_key_override().await? {
-            Ok(hyperlane_sovereign::Signer::new(&private_key)?)
-        } else if let SignerConf::HexKey { key } = conf {
+        if let SignerConf::HexKey { key } = conf {
             Ok(hyperlane_sovereign::Signer::new(key)?)
         } else {
             bail!("{conf:?} key is not supported by Sovereign");


### PR DESCRIPTION
Removes all support for the deprecated `TOKEN_KEY_FILE` env var that was used in the past to provision keys for rollup signer.